### PR TITLE
[DEPS] add missing material-ui dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "@babel/standalone": "^7.5.5",
     "@emotion/babel-preset-css-prop": "^10.0.17",
     "@emotion/core": "^10.0.14",
+    "@material-ui/core": "^4.5.0",
+    "@material-ui/icons": "^4.4.3",
     "babel-loader": "^8.0.6",
     "babel-plugin-emotion": "^10.0.14",
     "brace": "^0.11.1",


### PR DESCRIPTION
When doing a fresh install locally, I had to add in some MaterialUI dependancies to the `package.json`. We must have removed them at some point on accident, since we do rely on some core components and the icons.