### PR TITLE
Add basic settings structure

### DIFF
--- a/src/base-components/Headers.js
+++ b/src/base-components/Headers.js
@@ -1,0 +1,34 @@
+import React from 'react'
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core'
+
+const styles = {
+  h1: css`
+    margin: 8px 0 16px;
+    padding-bottom: 8px;
+    font-size: 22px;
+    border-bottom: solid 1px var(--color-background-highlight);
+  `,
+  h2: css`
+    margin: 8px 0;
+    font-size: 16px;
+  `,
+  h3: css`
+    margin: 8px 0;
+    font-size: 14px;
+  `,
+  h4: css`
+    margin: 8px 0;
+    font-size: 12px;
+  `,
+  h5: css`
+    margin: 8px 0;
+    font-size: 11px;
+  `,
+}
+
+export const H1 = ({children}) => <h1 css={styles.h1}>{children}</h1>
+export const H2 = ({children}) => <h2 css={styles.h2}>{children}</h2>
+export const H3 = ({children}) => <h3 css={styles.h3}>{children}</h3>
+export const H4 = ({children}) => <h4 css={styles.h4}>{children}</h4>
+export const H5 = ({children}) => <h5 css={styles.h5}>{children}</h5>

--- a/src/base-components/TextInput.js
+++ b/src/base-components/TextInput.js
@@ -1,0 +1,21 @@
+import React from 'react'
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core'
+
+const inputCss = css`
+  appearance: none;
+  padding: 8px;
+  font-size: 16px;
+  border: none;
+  width: 100%;
+  box-sizing: border-box;
+  border-radius: 3px;
+  background-color: var(--color-background-highlight);
+  color: var(--color-text);
+`
+
+export default function TextInput(props) {
+  return (
+    <input css={inputCss} {...props} />
+  )
+}

--- a/src/components/DemoRenderer.js
+++ b/src/components/DemoRenderer.js
@@ -7,6 +7,7 @@ import useLocalStorage from '../useLocalStorage'
 import canRender from '../lib/can-render'
 import ChildrenRenderer from './ChildrenRenderer'
 import ErrorBox from './ErrorBox'
+import SettingsProvider from './SettingsProvider'
 
 import '../global.css'
 
@@ -99,7 +100,7 @@ function ComponentDemo() {
   const canRenderComponent = componentInfo && canRender(componentInfo.props, propStates)
 
   return (
-    <>
+    <SettingsProvider>
       {componentInfo && propStates && (
         <DemoWrapper
           displayName={componentInfo.displayName}
@@ -123,7 +124,7 @@ function ComponentDemo() {
           )}
         </DemoWrapper>
       )}
-    </>
+    </SettingsProvider>
   )
 }
 

--- a/src/components/DemoWrapper.js
+++ b/src/components/DemoWrapper.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext } from 'react'
 /** @jsx jsx */
 import { Global, css, jsx } from '@emotion/core'
 import AppBar from '@material-ui/core/AppBar'
@@ -11,6 +11,8 @@ import EditDrawer from './EditDrawer'
 import ActivityBar from './ActivityBar'
 import SideBar from './SideBar'
 import Explorer from './Explorer'
+import Settings from './Settings'
+import { SettingsContext } from './SettingsProvider'
 
 const styles = {
   grid: css`
@@ -21,7 +23,6 @@ const styles = {
     display: flex;
   `,
   wrapper: css`
-    padding: 12px;
     flex-grow: 2;
     overflow-y: scroll;
     min-height: 0;
@@ -68,6 +69,8 @@ export default function DemoWrapper({
   const [editDrawerOpen, setEditDrawerOpen] = useLocalStorage('editDrawerOpen', true)
   const [editItem, setEditItem] = useLocalStorage(`${displayName}_editItem`, null)
 
+  const { settings } = useContext(SettingsContext)
+
   function updatePropState(propName, newState) {
     setPropStates(oldPropStates => ({
       ...oldPropStates,
@@ -85,9 +88,10 @@ export default function DemoWrapper({
         setDrawerView={setDrawerView}
       />
 
+      {/* SIDEBAR */}
       <SideBar open={drawerIsOpen}>
 
-
+        {/* PROPS VIEW */}
         {drawerView === 'props' &&
           <PropsDrawer
             propStates={propStates}
@@ -98,40 +102,17 @@ export default function DemoWrapper({
             resetToDefaults={resetToDefaults}
           />
         }
-
         
+        {/* EXPLORER VIEW */}
         {drawerView === 'explorer' && <Explorer />}
         
-        {drawerView === 'settings' && 'Settings'}
+        {/* SETTINGS VIEW */}
+        {drawerView === 'settings' && <Settings />}
 
       </SideBar>
-      <div css={styles.wrapper}>{children}</div>
 
-      {/* <div css={styles.main}>
-        <PropsDrawer
-          propStates={propStates}
-          open={drawerIsOpen && drawerView === 'props'}
-          propObjects={propObjects}
-          setEditItem={setEditItem}
-          updatePropState={updatePropState}
-          resetToDefaults={resetToDefaults}
-        />
-
-        <div
-          css={styles.contents}
-          style={{ gridTemplateRows: editDrawerOpen ? `1fr 1fr` : `auto` }}
-        >
-          <div css={styles.wrapper}>{children}</div>
-
-          <EditDrawer
-            open={editDrawerOpen}
-            setOpen={setEditDrawerOpen}
-            editItem={editItem}
-            setEditItem={setEditItem}
-            updatePropState={updatePropState}
-          />
-        </div>
-      </div> */}
+      {/* DEMO */}
+      <div css={styles.wrapper} style={{padding: settings.demoPadding + 'px'}}>{children}</div>
     </div>
   )
 }

--- a/src/components/PropsDrawer.js
+++ b/src/components/PropsDrawer.js
@@ -9,7 +9,6 @@ import ErrorBox from './ErrorBox'
 
 const styles = {
   propsContainer: css`
-    padding: 8px 16px;
     min-width: 250px;
     box-sizing: border-box;
     display: grid;

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -1,0 +1,21 @@
+import React, { useContext } from 'react'
+import { SettingsContext } from './SettingsProvider'
+
+import TextInput from '../base-components/TextInput'
+import { H1, H3 } from '../base-components/Headers'
+
+export default function Settings() {
+  const { settings, updateSetting } = useContext(SettingsContext)
+
+  const updateDemoPadding = ({ target: { value }}) => {
+    updateSetting('demoPadding',value && value >= 0 ? value : 0)
+  }
+
+  return (
+    <div>
+      <H1>Settings</H1>
+      <H3>Demo Padding</H3>
+      <TextInput type="number" value={settings.demoPadding} onChange={updateDemoPadding} />
+    </div>
+  )
+}

--- a/src/components/SettingsProvider.js
+++ b/src/components/SettingsProvider.js
@@ -1,0 +1,22 @@
+import React, { useState } from 'react'
+import useLocalStorage from '../useLocalStorage'
+
+export const SettingsContext = React.createContext()
+
+export default function SettingsProvider({children}) {
+  const [settings, setSettings] = useLocalStorage('react-draft-settings',{
+    demoPadding: 16
+  })
+
+  const updateSetting = (settingKey, newValue) => {
+    setSettings(prev => {
+      return {...prev, [settingKey]: newValue}
+    })
+  }
+
+  return (
+    <SettingsContext.Provider value={{settings, updateSetting}}>
+      {children}
+    </SettingsContext.Provider>
+  )
+}

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -3,13 +3,14 @@ import React from 'react'
 import { css, jsx } from '@emotion/core'
 
 const drawerCss = css`
-  padding-top: 8px;
+  padding: 16px;
   background-color: var(--color-background-secondary);
   transition: margin-right 0.2s ease-in-out;
   display: flex;
   flex-direction: column;
   width: 385px;
   color: var(--color-text);
+  box-sizing: border-box;
 `
 
 export default function SideBar({ open, children }) {

--- a/src/useLocalStorage.js
+++ b/src/useLocalStorage.js
@@ -11,7 +11,7 @@ export default function useLocalStorage(key, initialValue) {
       // Get from local storage by itemKey
       const item = window.localStorage.getItem(itemKey)
       // Parse stored json or if none return initialValue
-      return item !== undefined ? JSON.parse(item) : initialValue
+      return item !== undefined && item !== null ? JSON.parse(item) : initialValue
     } catch (error) {
       // If error also return initialValue
       console.log(error)


### PR DESCRIPTION
Adds the code structure for settings. 

This adds a new provider that will allow us to access the settings context anywhere in the app. The basic setting I added was for the padding wrapping around the demo component, so you can adjust it on the fly. Like so:

![2019-10-16 09 05 29](https://user-images.githubusercontent.com/16728078/66932063-43cbd000-eff4-11e9-9bd5-4c2ad1fc2a02.gif)

This also adds a new directory called "base-components" for building-block type components. Header components and a basic TextInput component have been added as well.
