### PR TITLE
[Issue-14] fix Explorer for Windows

### DIFF
--- a/src/components/Explorer.js
+++ b/src/components/Explorer.js
@@ -93,7 +93,7 @@ const evaluateFiles = (fileStructure) => {
   let fileTree = {}
 
   files.forEach(file => {
-    let paths = file.split('/').filter(x => x)
+    let paths = file.split(/[\\/]/).filter(x => x)
     let fileName = paths[paths.length - 1];
     paths = paths.slice(0, paths.length - 1)
     


### PR DESCRIPTION
Resolves #14

Since Windows uses backslashes, we will have to use a more flexible regex to split out file paths.

@zachintosh can you pull this down and test it out? I'm writing this on Linux and have no way of verifying that this actually works.