### PR TITLE
[NPM] publish pre-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 In your project's root directory, run:
 
 ```bash
-npm i @js-draft/react-draft
+npm i @digital-taco/react-draft
 ```
 
 In your project's `package.json`, add:
@@ -40,7 +40,7 @@ npm link
 Where you cloned `META-react-draft-sandbox`, run:
 
 ```bash
-npm link @js-draft/react-draft
+npm link @digital-taco/react-draft
 ```
 
 Run draft in the sandbox. Any changes made in `react-draft` will be picked up.

--- a/package.json
+++ b/package.json
@@ -1,12 +1,19 @@
 {
-  "name": "@js-draft/react-draft",
-  "version": "1.0.0",
-  "description": "",
+  "name": "@digital-taco/react-draft",
+  "version": "0.1.0",
+  "description": "Develop your React components in isolation without any configuration",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
+  "author": {
+    "name": "DigitalTaco",
+    "url": "https://github.com/digital-taco"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/digital-taco/react-draft.git"
+  },
   "license": "ISC",
   "dependencies": {
     "@babel/plugin-transform-runtime": "^7.5.0",


### PR DESCRIPTION
As you can [see here](https://www.npmjs.com/package/@digital-taco/react-draft), this now works:
```sh
npm publish
```

Does not _resolve_ #34 though. I ran `npx @digital-taco/react-draft` on a simple CRA app of mine and it failed with a file not found error. We will have to look into that.