### PR TITLE
Fix select in props view

### DIFF
--- a/src/Inputs/EnumInput.js
+++ b/src/Inputs/EnumInput.js
@@ -1,41 +1,19 @@
 import React from 'react'
-import Select from '@material-ui/core/Select'
-import FormControl from '@material-ui/core/FormControl'
-import OutlinedInput from '@material-ui/core/OutlinedInput'
-import InputLabel from '@material-ui/core/InputLabel'
+import InputLabel from '../base-components/InputLabel'
+import Select from '../base-components/Select'
 import { removeQuotes } from '../lib/helpers'
 
 export default function EnumInput({ propName, value, propObj, updatePropState }) {
-  // The value prop needs a default of a space to fix the input's label, for some reason...
-  const inputLabel = React.useRef(null)
-  const [labelWidth, setLabelWidth] = React.useState(0)
-  React.useEffect(() => {
-    setLabelWidth(inputLabel.current.offsetWidth)
-  }, [])
+  console.log('LOG: EnumInput -> value', value)
   return (
-    <FormControl variant="outlined">
-      <InputLabel margin="dense" ref={inputLabel} htmlFor={`${propName}_select`}>
-        {propName}
-      </InputLabel>
-      <Select
-        native
-        value={value}
-        variant="outlined"
-        onChange={e => updatePropState(propName, e.target.value)}
-        input={
-          <OutlinedInput
-            labelWidth={labelWidth}
-            margin="dense"
-            name="age"
-            id={`${propName}_select`}
-          />
-        }
-      >
+    <>
+      <InputLabel htmlFor={propName} label={propName} metaText="one of" />
+      <Select value={value || ''} onChange={e => updatePropState(propName, e.target.value)}>
         {propObj.type.value.map(option => {
           const trimmed = removeQuotes(option.value)
           return <option value={trimmed}>{trimmed || undefined}</option>
         })}
       </Select>
-    </FormControl>
+    </>
   )
 }

--- a/src/base-components/Headers.js
+++ b/src/base-components/Headers.js
@@ -4,10 +4,9 @@ import { css, jsx } from '@emotion/core'
 
 const styles = {
   h1: css`
-    margin: 8px 0 16px;
-    padding-bottom: 8px;
+    margin: 8px 0;
     font-size: 22px;
-    border-bottom: solid 1px var(--color-background-highlight);
+    /* border-bottom: solid 1px var(--color-background-highlight); */
   `,
   h2: css`
     margin: 8px 0;

--- a/src/base-components/IconButton.js
+++ b/src/base-components/IconButton.js
@@ -1,0 +1,47 @@
+import React from 'react'
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core'
+
+const buttonCss = css`
+  appearance: none;
+  text-transform: uppercase;
+  background-color: var(--color-background-highlight);
+  padding: 4px;
+  border-radius: 40px;
+  border: none;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.1s ease-out;
+  display: flex;
+  align-items: center;
+  height: 32px;
+
+  & > svg {
+    height: 24px;
+    width: 24px;
+    fill: var(--color-text-secondary);
+    transition: all 0.1s ease-out;
+  }
+
+  &:hover > svg {
+    fill: var(--color-text-hover);
+  }
+
+  &:hover {
+    background-color: var(--color-background-highlight2);
+  }
+  &:focus {
+    outline: none;
+  }
+  &:active {
+    opacity: 0.8;
+  }
+`
+
+export default function IconButton({ Icon, ...props }) {
+  return (
+    <button type="button" css={buttonCss} {...props}>
+      <Icon />
+    </button>
+  )
+}

--- a/src/base-components/Select.js
+++ b/src/base-components/Select.js
@@ -1,0 +1,41 @@
+import React from 'react'
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core'
+
+const selectWrapperCss = css`
+  &::after {
+    content: '';
+    border: solid white;
+    border-width: 0 3px 3px 0;
+    display: inline-block;
+    padding: 3px;
+    transform: rotate(45deg);
+    position: absolute;
+    right: 12px;
+    top: calc(50% - 6px);
+  }
+`
+
+const inputCss = css`
+  appearance: none;
+  padding: 8px;
+  font-size: 16px;
+  border: none;
+  width: 100%;
+  box-sizing: border-box;
+  border-radius: 3px;
+  background-color: var(--color-background-highlight);
+  color: var(--color-text);
+`
+
+export default function Select({ children, value, ...props }) {
+  return (
+    <div style={{ position: 'relative' }}>
+      <div css={selectWrapperCss}>
+        <select css={inputCss} value={value} {...props}>
+          {children}
+        </select>
+      </div>
+    </div>
+  )
+}

--- a/src/components/PropsDrawer.js
+++ b/src/components/PropsDrawer.js
@@ -1,13 +1,14 @@
 import React, { useContext } from 'react'
 /** @jsx jsx */
 import { css, jsx } from '@emotion/core'
-import amber from '@material-ui/core/colors/amber'
 import Button from '../base-components/Button'
 import getInput from '../lib/get-input'
 // import ChildrenInput from '../Inputs/ChildrenInput'
 import ErrorBox from './ErrorBox'
 import { H1 } from '../base-components/Headers'
 import { SelectedContext } from './SelectedProvider'
+import ResetIcon from '../svgs/ResetIcon'
+import IconButton from '../base-components/IconButton'
 
 const styles = {
   propsContainer: css`
@@ -17,16 +18,6 @@ const styles = {
     grid-row-gap: 8px;
     overflow-y: scroll;
     max-height: 100%;
-
-    & .MuiFormControl-root {
-      width: 100%;
-      margin-top: 8px;
-      margin-bottom: 4px;
-    }
-
-    & .Mui-required:not(.MuiFormLabel-filled) {
-      color: ${amber[900]};
-    }
   `,
   propsDrawer: css`
     display: flex;
@@ -36,6 +27,12 @@ const styles = {
     margin-top: 24px;
   `,
 }
+
+const propsTitleCss = css`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`
 
 export default function PropsDrawer({ propObjects, open, setEditItem }) {
   if (!propObjects) return null
@@ -71,7 +68,14 @@ export default function PropsDrawer({ propObjects, open, setEditItem }) {
 
   return (
     <>
-      <H1>{SelectedComponent.meta.displayName} Props</H1>
+      <div css={propsTitleCss}>
+        <H1>{SelectedComponent.meta.displayName} Props</H1>
+        <IconButton
+          title="Reset all props to default values"
+          Icon={ResetIcon}
+          onClick={resetToDefaults}
+        />
+      </div>
       <div css={styles.propsDrawer} style={style} className="demo-font">
         <div css={styles.propsContainer}>
           {/* <ChildrenInput value={propStates.children} setEditItem={setEditItem} /> */}
@@ -89,12 +93,6 @@ export default function PropsDrawer({ propObjects, open, setEditItem }) {
           {inputs.missingPropTypes.map(([propName]) => (
             <ErrorBox label={propName} error="Missing PropType" />
           ))}
-
-          <div css={styles.resetButton}>
-            <Button size="small" color="primary" onClick={resetToDefaults}>
-              Reset to Defaults
-            </Button>
-          </div>
         </div>
       </div>
     </>

--- a/src/svgs/ResetIcon.js
+++ b/src/svgs/ResetIcon.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function ResetIcon(props) {
+  return (
+    <svg focusable="false" viewBox="0 0 24 24" aria-hidden="true" role="presentation" {...props}>
+      <path d="M7.11 8.53L5.7 7.11C4.8 8.27 4.24 9.61 4.07 11h2.02c.14-.87.49-1.72 1.02-2.47zM6.09 13H4.07c.17 1.39.72 2.73 1.62 3.89l1.41-1.42c-.52-.75-.87-1.59-1.01-2.47zm1.01 5.32c1.16.9 2.51 1.44 3.9 1.61V17.9c-.87-.15-1.71-.49-2.46-1.03L7.1 18.32zM13 4.07V1L8.45 5.55 13 10V6.09c2.84.48 5 2.94 5 5.91s-2.16 5.43-5 5.91v2.02c3.95-.49 7-3.85 7-7.93s-3.05-7.44-7-7.93z" />
+    </svg>
+  )
+}


### PR DESCRIPTION
Does two things:

- Fixes the select component to work with the new setup and removes @material-ui form it
- Moves the "Reset to Defaults" button to an icon button next to the props view title

![2019-11-25 09 28 29](https://user-images.githubusercontent.com/16728078/69558836-27617280-0f66-11ea-90f6-7a838b0a8a71.gif)
