### PR TITLE
Set the page title to the CWD's package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-taco/react-draft",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Develop your React components in isolation without any configuration",
   "main": "index.js",
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const fs = require('fs')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const webpack = require('webpack')
 const BuildExportsList = require('./lib/BuildExportsList')
@@ -9,6 +10,10 @@ const hotMiddlewareScript =
 module.exports = draftConfig => {
   const includedNodeModules = (draftConfig.additionalReactModules || []).join('|')
   const excludedNodeModules = new RegExp(`node_modules/(?!${includedNodeModules})`)
+
+  // Set the title of the page to the CWD package name
+  const packagePath = path.resolve('.', 'package.json')
+  let { name: packageName } = fs.existsSync(packagePath) ? require(packagePath) : null
 
   const config = {
     context: path.resolve('.'),
@@ -34,6 +39,7 @@ module.exports = draftConfig => {
         chunks: ['runtime~demo', 'demo', 'vendors', 'demo~draft-main'],
       }),
       new HtmlWebpackPlugin({
+        title: `Draft | ${packageName.split('/').pop()}`,
         filename: 'index.html',
         chunks: ['runtime~draft-main', 'demo~draft-main', 'draft-main', 'vendors'],
       }),


### PR DESCRIPTION
Sets the page title to the current working directory's package name. For example, running it in the lunar bears sandbox sets the title to `Draft | draft-sandbox`, since the page name is `@digital-taco/draft-sandbox`.