### PR TITLE
[EditDrawer] fix cross iframe communication issues + other things

### DIFF
--- a/src/Inputs/FunctionInput.js
+++ b/src/Inputs/FunctionInput.js
@@ -12,20 +12,22 @@ const styles = {
   `,
 }
 
-export default function FunctionInput({ propName, value, warnings = [], setEditItem, valueType }) {
+export default function FunctionInput({ propName, value, warnings = [], setEditItem, valueType, openEditDrawer }) {
   return (
     <div css={styles.objectContainer}>
       <InputLabel label={propName} metaText={valueType || 'object'} />
       <Button
         variant="text"
         dense
-        onClick={() =>
+        onClick={() => {
           setEditItem({
             propName,
             value,
             warnings,
             valueType,
           })
+          openEditDrawer()
+        }
         }
       >
         Edit

--- a/src/components/ActivityBar.js
+++ b/src/components/ActivityBar.js
@@ -53,7 +53,8 @@ export default function ActivityBar() {
 
   // Add keyboard shortcuts
   useEffect(() => {
-    function handleKeyShortcut({ keyCode }) {
+    function handleKeyShortcut({ keyCode, target }) {
+      if (['input', 'textarea'].includes(target.tagName.toLowerCase())) return
       if (keyCode === 65) handleClick('explorer')
       if (keyCode === 83) handleClick('props')
       if (keyCode === 68) handleClick('settings')

--- a/src/components/Demo.js
+++ b/src/components/Demo.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import ReactDOM from 'react-dom'
-import { msg, parseMsg } from '../lib/helpers'
+import { msg, parseMsg, deserialize } from '../lib/helpers'
 import Components from '../../out/master-exports'
 import ErrorBoundary from './ErrorBoundary'
 
@@ -8,6 +8,10 @@ import ErrorBoundary from './ErrorBoundary'
 const container = document.createElement('div')
 document.body.appendChild(container)
 container.setAttribute('id', 'demo')
+
+function deserializeAll(states) {
+  return Object.fromEntries(Object.entries(states).map(([s,v]) => [s, deserialize(v)]))
+}
 
 function Page() {
   const [SelectedComponent, setSelectedComponent] = useState(null)
@@ -44,7 +48,7 @@ function Page() {
   return SelectedComponent ? (
     <ErrorBoundary key={SelectedComponent.meta.componentHash}>
       <DemoWrapper>
-        {SelectedComponent && <SelectedComponent {...propStates} />}
+        {SelectedComponent && <SelectedComponent {...deserializeAll(propStates)} />}
       </DemoWrapper>
     </ErrorBoundary>
   ) : null

--- a/src/components/DemoWrapper.js
+++ b/src/components/DemoWrapper.js
@@ -82,6 +82,7 @@ export default function DemoWrapper({ propObjects, children, componentTree }) {
             open={drawerIsOpen && drawerView === 'props'}
             propObjects={propObjects}
             setEditItem={setEditItem}
+            openEditDrawer={() => setItem('DRAFT_edit_drawer_open', true)}
           />
         )}
 

--- a/src/components/EditDrawer.js
+++ b/src/components/EditDrawer.js
@@ -5,6 +5,7 @@ import AceEditor from 'react-ace'
 import { SelectedContext } from './SelectedProvider'
 import 'brace/mode/json'
 import 'brace/theme/tomorrow_night_bright'
+import { serialize, deserialize } from '../lib/helpers'
 
 const styles = {
   editDrawer: css`
@@ -147,7 +148,7 @@ export default function EditDrawer({ open, setOpen, editItem, setEditItem }) {
         value={
           typeof editItem.value === 'object'
             ? JSON.stringify(editItem.value, null, 4)
-            : editItem.value
+            : deserialize(editItem.value, false)
         }
         theme="tomorrow_night_bright"
         name="test editor"
@@ -168,8 +169,8 @@ export default function EditDrawer({ open, setOpen, editItem, setEditItem }) {
               newValue = newText ? eval(`() => (${newText})`)() : undefined // eslint-disable-line
             }
 
-            console.log('TCL: EditDrawer -> newValue', newValue)
-            updatePropState(editItem.propName, newValue) // eslint-disable-line
+            const serialized = serialize(newValue)
+            updatePropState(editItem.propName, serialized) // eslint-disable-line
             setEditItem({ ...editItem, value: newText })
           } catch (e) {
             console.error(e)
@@ -179,3 +180,4 @@ export default function EditDrawer({ open, setOpen, editItem, setEditItem }) {
     </div>
   )
 }
+// x=>console.log(x)

--- a/src/components/PropsDrawer.js
+++ b/src/components/PropsDrawer.js
@@ -27,7 +27,7 @@ const propsTitleCss = css`
   align-items: center;
 `
 
-export default function PropsDrawer({ propObjects, open, setEditItem }) {
+export default function PropsDrawer({ propObjects, open, setEditItem, openEditDrawer }) {
   if (!propObjects) return null
 
   const { SelectedComponent, propStates, resetToDefaults, updatePropState } = useContext(
@@ -56,7 +56,7 @@ export default function PropsDrawer({ propObjects, open, setEditItem }) {
   }
 
   function getInputProp(entry) {
-    return getInput(entry, propStates, updatePropState, setEditItem)
+    return getInput(entry, propStates, updatePropState, setEditItem, openEditDrawer)
   }
 
   return (

--- a/src/lib/get-input.js
+++ b/src/lib/get-input.js
@@ -6,7 +6,7 @@ import ObjectInput from '../Inputs/ObjectInput'
 import ShapeInput from '../Inputs/ShapeInput'
 import FunctionInput from '../Inputs/FunctionInput'
 
-export default function getInput([propName, propObj], propStates, updatePropState, setEditItem) {
+export default function getInput([propName, propObj], propStates, updatePropState, setEditItem, openEditDrawer) {
   const inputMap = {
     string: (
       <StringNumberInput
@@ -82,6 +82,7 @@ export default function getInput([propName, propObj], propStates, updatePropStat
         value={propStates[propName]}
         propObj={propObj}
         setEditItem={setEditItem}
+        openEditDrawer={openEditDrawer}
         valueType="function"
         strict
       />

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -1,3 +1,6 @@
+// -------------------------------------------------------
+// UTIL
+// -------------------------------------------------------
 export function isJson(str) {
   try {
     const parsed = JSON.parse(str)
@@ -6,6 +9,14 @@ export function isJson(str) {
     return false
   }
 }
+
+export function removeQuotes(str) {
+  return str.replace(/(^("|')|("|')$)/g, '')
+}
+
+// -------------------------------------------------------
+// CROSS-IFRAME COMMUNICATION
+// -------------------------------------------------------
 
 const sourceToken = 'react-draft'
 
@@ -20,6 +31,20 @@ export function parseMsg(fn) {
   }
 }
 
-export function removeQuotes(str) {
-  return str.replace(/(^("|')|("|')$)/g, '')
+// -------------------------------------------------------
+// DATA SERIALIZATION FOR COMPLEX INFORMATION
+// -------------------------------------------------------
+
+const SERIALIZED_TOKEN = '::SERIALIZED::'
+
+export function serialize(item) {
+  const processed = SERIALIZED_TOKEN + encodeURI(item.toString())
+  return processed
+}
+
+export function deserialize (item, evaluate = true) {
+  const needsProccessing = typeof item === 'string' && item.startsWith(SERIALIZED_TOKEN)
+  let processed = needsProccessing ? decodeURI(item.replace(SERIALIZED_TOKEN, '')) : item
+  processed = needsProccessing && evaluate ? eval(`(()=>(${processed}))();`) : processed
+  return processed
 }

--- a/test/index.sh
+++ b/test/index.sh
@@ -17,7 +17,7 @@ cd test/sandbox
 git clone https://github.com/digital-taco/react-draft-testing
 cd react-draft-testing
 npm install;
-npm link react-draft
+npm link @digital-taco/react-draft
 
 npm run draft&
 


### PR DESCRIPTION
THIS THING IS STILL SUPER BUGGY

But... I did figure out how to serialize & send real functions between the `iframe` and the main window. 

Also I fixed the bug where the `a` `s` and `d` keys would open/close the activities as you type in propType inputs and in the edit drawer. 

Also updated the tests to use the correct package name. Not sure how npm was ever resolving to the right one, but now it does for sure. 

![2019-12-04 21-33](https://user-images.githubusercontent.com/18150457/70204507-1212e380-16de-11ea-8f3f-ce0d4313576f.gif)
