### PR TITLE
Add config for custom middleware, allow regexes for ignore config

### DIFF
--- a/bin/launch.js
+++ b/bin/launch.js
@@ -12,9 +12,12 @@ const buildWebpackConfig = require('../webpack.config')
 const buildComponentTree = require('../lib/build-component-tree.js')
 const buildMasterExports = require('../lib/build-master-exports.js')
 const reactConfigPath = path.resolve('.', 'draft.config.js')
+
 const draftConfig = fs.existsSync(reactConfigPath) ? require(reactConfigPath) : {
   middleware: () => {}
 }
+
+const { babelModules = [], ignore = [] } = draftConfig
 
 const files = find.fileSync(/\.js$/, path.resolve('.')).filter(fp => {
   if (fp.includes('node_modules/')) return false

--- a/bin/launch.js
+++ b/bin/launch.js
@@ -21,7 +21,7 @@ const { babelModules = [], ignore = [] } = draftConfig
 
 const files = find.fileSync(/\.js$/, path.resolve('.')).filter(fp => {
   if (fp.includes('node_modules/')) return false
-  return !draftConfig.ignore.some(ignorePath => {
+  return !ignore.some(ignorePath => {
     if (ignorePath instanceof RegExp) {
       return ignorePath.exec(fp)
     } else if (typeof ignorePath === 'string') {
@@ -69,7 +69,7 @@ const devMiddleware = middleware(compiler, {
   stats: {
     builtAt: false,
     colors: true,
-    timings: true,
+    timings: false,
     entrypoints: false,
     assets: false,
     modules: false,

--- a/bin/launch.js
+++ b/bin/launch.js
@@ -14,11 +14,20 @@ const buildComponentTree = require('../lib/build-component-tree.js')
 const buildMasterExports = require('../lib/build-master-exports.js')
 
 const reactConfigPath = path.resolve('.', 'draft.config.js')
-const draftConfig = fs.existsSync(reactConfigPath) ? require(reactConfigPath) : {}
+const draftConfig = fs.existsSync(reactConfigPath) ? require(reactConfigPath) : {
+  middleware: () => {}
+}
 
-const files = find.fileSync(/\.js$/, path.resolve('.')).filter(x => {
-  return !['node_modules/', ...(draftConfig.ignore || [])].some(ignorePath => {
-    return x.includes(ignorePath)
+const files = find.fileSync(/\.js$/, path.resolve('.')).filter(fp => {
+  if (fp.includes('node_modules/')) return false
+  return !draftConfig.ignore.some(ignorePath => {
+    if (ignorePath instanceof RegExp) {
+      return ignorePath.exec(fp)
+    } else if (typeof ignorePath === 'string') {
+      return fp.includes(ignorePath)
+    } else {
+      console.error(`Invalid Configuration: ignore value of ${ignorePath} invalid. Must be a regular expression or a string.`)
+    }
   })
 })
 
@@ -86,6 +95,9 @@ const extractFrom = (webpackCompiler, name) => (req, res, next) => {
 }
 
 // Must be added _after_ the dev middleware
+draftConfig.middleware(app)
+
+// Add demo and index middleware
 app.use('/demo', extractFrom(compiler, 'demo.html'))
 app.use('/', extractFrom(compiler, 'index.html'))
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,7 +96,7 @@ module.exports = draftConfig => {
             path.resolve('.', '..'),
             // ...(draftConfig.additionalReactModules || []),
           ],
-          exclude: [excludedNodeModules, /.*\.stories\.js$/],
+          exclude: [excludedNodeModules],
           use: [
             'cache-loader',
             {


### PR DESCRIPTION
Adds the ability to give custom middleware in your `draft.config.js` file, under the `middleware` option. This is so users can add authentication, etc. to draft in their apps. This PR also adds functionality for regexes to be used in the `ignore` config option.

Lunar bears has been updated to show these changes.