### PR TITLE
Update tab behavior so there is always a tab (mostly)

### DIFF
--- a/src/components/Demo.js
+++ b/src/components/Demo.js
@@ -13,10 +13,10 @@ function Page() {
   const [propStates, setPropStates] = useState({})
 
   function receiveMessage(type, data) {
-    if (process.env.DEBUG) console.log('DEMO | Message Received: ', type, data)
     switch (type) {
       // When a new component is selected in the explorer
       case 'SELECTED_COMPONENT':
+        if (process.env.DEBUG) console.log('DEMO | Message Received: ', type, data)
         setSelectedComponent(() => Components[data.componentHash])
         break
 
@@ -47,7 +47,7 @@ function Page() {
         {SelectedComponent && <SelectedComponent {...deserializeAll(propStates)} />}
       </Wrapper>
     </ErrorBoundary>
-  ) : null
+  ) : <div>No demo, son</div>
 }
 
 // Render the demo in the dom

--- a/src/components/Draft.js
+++ b/src/components/Draft.js
@@ -49,12 +49,12 @@ function Page() {
   }, [])
 
   useEffect(() => {
-    messageSelectedComponent(), [SelectedComponent]
-  })
+    messageSelectedComponent()
+  }, [SelectedComponent])
 
   useEffect(() => {
-    messagePropStates(), [propStates]
-  })
+    messagePropStates()
+  }, [propStates])
 
   return (
     <DemoWrapper propObjects={props} componentTree={componentTree}>

--- a/src/components/SelectedProvider.js
+++ b/src/components/SelectedProvider.js
@@ -85,10 +85,13 @@ export default function SelectedProvider({ children, components }) {
 
   /** Updates the currently selected component, identified by filepath */
   function updateSelectedComponent(filePath, displayName) {
-    const componentEntry = Object.entries(components).find(([, Component]) => {
-      return Component.meta.filePath === filePath && Component.meta.displayName === displayName
-    })
-    setItem('DRAFT_Selected_Component_Hash', componentEntry[0])
+    if (filePath === null) setItem('DRAFT_Selected_Component_Hash', 'none')
+    else {
+      const componentEntry = Object.entries(components).find(([, Component]) => {
+        return Component.meta.filePath === filePath && Component.meta.displayName === displayName
+      })
+      setItem('DRAFT_Selected_Component_Hash', componentEntry[0])
+    }
   }
 
   /** Resets all props to their default values */


### PR DESCRIPTION
Makes it so clicking a component in the explorer opens a temporary tab.

Clicking it again makes the tab persist.

Closing the currently selected tab will adjust the selected component to the tab to the left, unless it is the first tab. Then it selects the one on the right.