### PR TITLE
[EditDrawer] fix the excecute on load/editing bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-taco/react-draft",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Develop your React components in isolation without any configuration",
   "main": "index.js",
   "scripts": {

--- a/src/components/Draft.js
+++ b/src/components/Draft.js
@@ -52,12 +52,12 @@ function Page() {
   }, [])
 
   useEffect(() => {
-    messageSelectedComponent(), [SelectedComponent]
-  })
+    messageSelectedComponent()
+  }, [SelectedComponent])
 
   useEffect(() => {
-    messagePropStates(), [propStates]
-  })
+    messagePropStates()
+  }, [propStates])
 
   return (
     <DemoWrapper propObjects={props} componentTree={componentTree}>

--- a/src/components/draft/EditDrawer.js
+++ b/src/components/draft/EditDrawer.js
@@ -90,7 +90,7 @@ const warningCss = css`
 /** A bottom-opening drawer containing an editor. Allows the user to edit the prop state for objects, shapes, and exact shapes. */
 export default function EditDrawer({ open, setOpen, editItem, setEditItem }) {
   if (!editItem) return null
-  const [editorValue, setEditorValue] = useState(deserialize(editItem.value))
+  const [editorValue, setEditorValue] = useState(deserialize(editItem.value, false))
   const [warningsOpen, setWarningsOpen] = useState(false)
   const [hasError, setHasError] = useState(false)
   const { updatePropState } = useContext(SelectedContext)
@@ -196,7 +196,6 @@ export default function EditDrawer({ open, setOpen, editItem, setEditItem }) {
         theme="tomorrow_night_bright"
         name="test editor"
         onChange={newValue => {
-          console.log('LOG: newValue', newValue)
           setEditorValue(newValue)
         }}
       />


### PR DESCRIPTION
When the edit drawer was reopened, it tried to execute that function. This bug solves that. 