### PR TITLE
Work offline, fix some transpile issues, work on mobile

### DIFF
--- a/bin/launch.dev.js
+++ b/bin/launch.dev.js
@@ -18,7 +18,7 @@ const draftConfig = fs.existsSync(reactConfigPath) ? require(reactConfigPath) : 
 const { babelModules = [], ignore = [], port = 8080, openAtLaunch = true } = draftConfig
 const joinedIncludedNodesModules = babelModules.join('|')
 
-log.verbose('Launching Draft')
+log('Launching...', ['Dev'])
 
 const draftWebpackConfig = require('../config/draft.webpack')(draftConfig)
 const demoWebpackConfig = require('../config/demo.webpack')(draftConfig)

--- a/bin/launch.prod.js
+++ b/bin/launch.prod.js
@@ -15,6 +15,8 @@ const getFileStructure = require('../lib/get-files')
 const { getComponentGlossary } = require('../lib/get-component-glossary')
 const statsOptions = require('../config/stats-options')
 
+log('Launching...')
+
 const reactConfigPath = path.resolve('.', 'draft.config.js')
 const draftConfig = fs.existsSync(reactConfigPath) ? require(reactConfigPath) : {}
 const { babelModules = [], ignore = [], port = 8080, openAtLaunch = true } = draftConfig

--- a/config/demo.webpack.js
+++ b/config/demo.webpack.js
@@ -13,6 +13,7 @@ module.exports = draftConfig => {
   const { babelModules = [], babelConfig = {} } = draftConfig
 
   const draftBabelConfig = buildBabelConfig(babelConfig)
+
   const { includedModules, excludedModules } = getInclusionRules(babelModules, [
     path.resolve('.'),
     path.resolve(__dirname, '../src/components/Demo.js'),
@@ -67,7 +68,6 @@ module.exports = draftConfig => {
         react: resolvePackagePath('react'),
         // react-hot-loader alters react-dom, so we need to resolve to the altered version
         'react-dom': resolvePackagePath('@hot-loader/react-dom'),
-        '@emotion/core': resolvePackagePath('@emotion/core'),
       },
     },
 
@@ -119,10 +119,13 @@ module.exports = draftConfig => {
 
     module: {
       rules: [
+        // IGNORE LOADER
         {
           test: /\.mdx$/,
           use: 'ignore-loader',
         },
+
+        // BABEL LOADER
         {
           test: /(\.js|\.jsx)$/,
           include: includedModules,
@@ -140,10 +143,14 @@ module.exports = draftConfig => {
             },
           ],
         },
+
+        // FILE LOADER
         {
           test: /\.(jpg|jpeg|png|gif|ttf|ttf2|woff|woff2|svg)$/,
           loader: 'file-loader?name=[name].[ext]',
         },
+
+        // STYLE LOADER
         {
           test: /\.css$/,
           use: [

--- a/config/draft.webpack.js
+++ b/config/draft.webpack.js
@@ -105,10 +105,11 @@ module.exports = () => {
               options: {
                 cacheDirectory: true,
                 cacheCompression: false,
+                configFile: false, // Without this, babel searches for a babel config - which means it will pick up the user's config if they have one
                 presets: [
                   ['@babel/preset-env', { targets: { node: 'current' }, modules: false }],
                   '@babel/preset-react',
-                  require.resolve('@emotion/babel-preset-css-prop'),
+                  require('@emotion/babel-preset-css-prop').default,
                 ],
                 plugins: ['@babel/plugin-syntax-dynamic-import'],
               },

--- a/lib/config-helpers.js
+++ b/lib/config-helpers.js
@@ -35,7 +35,7 @@ function getInclusionRules(babelModules, additionalPaths = []) {
   }
 }
 
-function buildBabelConfig(customBabelConfig) {
+function buildBabelConfig(customBabelConfig, additionalPresets = [], additionalPlugins = []) {
   return {
     ...customBabelConfig,
     presets: [
@@ -43,7 +43,7 @@ function buildBabelConfig(customBabelConfig) {
         ...(customBabelConfig.presets || []),
         '@babel/preset-react',
         ['@babel/preset-env', { targets: { esmodules: true } }],
-        require.resolve('@emotion/babel-preset-css-prop'),
+        ...additionalPresets,
       ]),
     ],
     plugins: [
@@ -51,6 +51,7 @@ function buildBabelConfig(customBabelConfig) {
         ...(customBabelConfig.plugins || []),
         '@babel/plugin-syntax-dynamic-import',
         '@babel/plugin-transform-runtime',
+        ...additionalPlugins,
       ]),
     ],
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-taco/react-draft",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "Develop your React components in isolation without any configuration",
   "main": "bin/launch.prod.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@babel/runtime": "^7.8.3",
     "@babel/runtime-corejs2": "^7.5.4",
     "@babel/runtime-corejs3": "^7.5.4",
+    "@babel/standalone": "^7.9.3",
     "@emotion/babel-preset-css-prop": "^10.0.17",
     "@emotion/core": "^10.0.14",
     "@hot-loader/react-dom": "^16.11.0",

--- a/src/components/Draft.js
+++ b/src/components/Draft.js
@@ -1,4 +1,4 @@
-import React, { useContext, useRef, useEffect } from 'react'
+import React, { useState, useContext, useRef, useEffect } from 'react'
 import ReactDOM from 'react-dom'
 import { hot } from 'react-hot-loader'
 import DemoWrapper from './draft/DemoWrapper'
@@ -19,6 +19,7 @@ function Page() {
 
   const canRenderComponent = propStates && canRender(props, propStates)
   const handleMessage = parseMsg(receiveMessage)
+  const [packageName, setPackageName] = useState('')
 
   const messageSelectedComponent = () =>
     msg(
@@ -36,20 +37,29 @@ function Page() {
       messageSelectedComponent()
       messagePropStates()
     } else if (type === 'PACKAGE_NAME') {
-      document.title = `Draft - ${SelectedComponent.componentHash !== 'EmptyDemo' &&
-        SelectedComponent.displayName} (${data})`
+      setPackageName(data)
     }
   }
 
+  // Set the document title
+  useEffect(() => {
+    document.title = `Draft ${
+      SelectedComponent.componentHash !== 'EmptyDemo' ? `- ${SelectedComponent.displayName}` : ''
+    } ${packageName && `(${packageName})`}`
+  }, [SelectedComponent, packageName])
+
+  // Add iframe message system handler
   useEffect(() => {
     window.addEventListener('message', handleMessage)
     return () => window.removeEventListener('message', handleMessage)
   }, [])
 
+  // Each time the SelectedComponent updates, update the demo iframe
   useEffect(() => {
     messageSelectedComponent()
   }, [SelectedComponent])
 
+  // Each time the prop states update, update the demo iframe
   useEffect(() => {
     messagePropStates()
   }, [propStates])

--- a/src/components/demo/EmptyDemo.js
+++ b/src/components/demo/EmptyDemo.js
@@ -1,20 +1,9 @@
 import React from 'react'
-import { css } from '@emotion/core'
-
-const emptyDemoCss = css`
-  padding: 40px;
-  height: 100vh;
-  width: 100vw;
-  box-sizing: border-box;
-
-  & > * {
-    text-align: center;
-  }
-`
+import styles from './demo.module.css'
 
 export default function EmptyDemo() {
   return (
-    <div css={emptyDemoCss}>
+    <div className={styles.emptyDemo}>
       <div>Please select a component to display</div>
     </div>
   )

--- a/src/components/demo/ErrorBoundary.js
+++ b/src/components/demo/ErrorBoundary.js
@@ -1,26 +1,5 @@
 import React from 'react'
-import { css } from '@emotion/core'
-
-const errorCss = css`
-  background: #fcc;
-  color: #911;
-  padding: 20px;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
-    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-`
-
-const messageCss = css`
-  margin-bottom: 16px;
-  font-size: 20px;
-  font-weight: bold;
-`
-
-const stackCSs = css`
-  white-space: pre-wrap;
-  overflow-wrap: break-word;
-`
+import styles from './demo.module.css'
 
 export default class ErrorBoundary extends React.Component {
   constructor(props) {
@@ -34,13 +13,15 @@ export default class ErrorBoundary extends React.Component {
   }
 
   render() {
-    return this.state.hasError ? (
-      <div css={errorCss}>
-        <div css={messageCss}>{this.state.error.message}</div>
-        <div css={stackCSs}>{this.state.error.stack}</div>
+    const { error, hasError } = this.state
+    const { children } = this.props
+    return hasError ? (
+      <div css={styles.error}>
+        <div css={styles.message}>{error.message}</div>
+        <div css={styles.stack}>{error.stack}</div>
       </div>
     ) : (
-      this.props.children
+      children
     )
   }
 }

--- a/src/components/demo/demo.module.css
+++ b/src/components/demo/demo.module.css
@@ -1,0 +1,31 @@
+.emptyDemo {
+  padding: 40px;
+  height: 100vh;
+  width: 100vw;
+  box-sizing: border-box;
+}
+
+.emptyDemo > * {
+  text-align: center;
+}
+
+.error {
+  background: #fcc;
+  color: #911;
+  padding: 20px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.message {
+  margin-bottom: 16px;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.stack {
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}

--- a/src/components/draft/DemoJSX.js
+++ b/src/components/draft/DemoJSX.js
@@ -60,7 +60,7 @@ export default function DemoJSX() {
   // This bit of logic removes any undefined prop states from our deserialized values
   const { props = {} } = SelectedComponent
   Object.entries(deserializedPropStates).forEach(([k, v]) => {
-    let { value: defaultValue } = props[k].defaultValue || {}
+    let { value: defaultValue } = (props[k] && props[k].defaultValue) || {}
     if (
       typeof defaultValue === 'string' &&
       quoteRegExp.test(defaultValue[0]) &&

--- a/src/lib/transpile-jsx.js
+++ b/src/lib/transpile-jsx.js
@@ -1,9 +1,11 @@
+import * as Babel from '@babel/standalone'
+
 export function isJsxString(str) {
   return str && /(<|\()/.test(str[0])
 }
 
 export function transpile(jsx) {
-  return window.Babel.transform(jsx, {
+  return Babel.transform(jsx, {
     presets: ['es2015', 'react'],
     parserOpts: { sourceType: 'script', minified: true },
   }).code

--- a/templates/demo.html
+++ b/templates/demo.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body>
     <div id="demo"></div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,11 +2,10 @@
 <html>
   <head>
     <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>
     <div id="app"></div>
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js" data-presets="es2015,react"></script>
   </body>
 </html>


### PR DESCRIPTION
resolves #118 
resolves #119 
resolves #120

Re-implements @babel/standalone, rather than using the CDN script for it. This allows draft to work offline.

Fixes the title of the document so it doesn't display "false" anymore when there isn't a component selected.