### PR TITLE
[test] fix tests that have been broken for a while

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 dist: trusty
 node_js:
-  - '10'
+  - '12'
 install:
   - npm install
 script:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-taco/react-draft",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "description": "Develop your React components in isolation without any configuration",
   "main": "bin/launch.prod.js",
   "scripts": {

--- a/test/react-draft.test.js
+++ b/test/react-draft.test.js
@@ -1,22 +1,27 @@
 const { cleanup, renderPage } = require('./setup')
 
-afterAll(cleanup);
+afterAll(cleanup)
 
 test(`Should be able to switch between Activities`, () => {
-  return renderPage().then(async ({ browser, page }) => {
-    await page.waitFor('[data-test-explorer-icon]');
+  return renderPage().then(async ({ page }) => {
+    await page.waitFor('[data-test-explorer-icon]')
 
     async function checkActivities() {
-      return await page.evaluate(() => {
-        let explorer = document.querySelector('[data-test-explorer-icon]').dataset.selected === ''
-        let props = document.querySelector('[data-test-props-icon]').dataset.selected === ''
-        let settings = document.querySelector('[data-test-settings-icon]').dataset.selected === ''
-        return {explorer, props, settings}
+      return page.evaluate(() => {
+        const explorer =
+          document.querySelector('[data-test-explorer-icon]').parentElement.dataset.selected === ''
+        const props =
+          document.querySelector('[data-test-props-icon]').parentElement.dataset.selected === ''
+        const code =
+          document.querySelector('[data-test-code-icon]').parentElement.dataset.selected === ''
+        const settings =
+          document.querySelector('[data-test-settings-icon]').parentElement.dataset.selected === ''
+        return { explorer, props, code, settings }
       })
     }
 
     // Explorer should already be selected
-    let testExplorer = await checkActivities()
-    expect(testExplorer).toEqual({explorer: true, props: false, settings: false})
+    const testExplorer = await checkActivities()
+    expect(testExplorer).toEqual({ explorer: true, props: false, code: false, settings: false })
   })
 }, 30000) // first tests sometimes take a while while the page loads


### PR DESCRIPTION
At some point we moved a `data-selected` attribute from the `<svg>` to the `<div>` wrapping it. Not sure how long these have been broken, but probably since we last rand the tests.